### PR TITLE
Update openssl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 FROM --platform=linux/amd64 node:18.15.0-alpine as builder
-RUN apk add --update --no-cache openssl1.1-compat
+RUN apk add --update --no-cache openssl
 USER node
 WORKDIR /tmp/build/app
 
@@ -15,7 +15,7 @@ COPY --chown=node:node src ./src
 RUN yarn build
 
 FROM --platform=linux/amd64 node:18.15.0-alpine as ts-node-module-prod
-RUN apk add --update --no-cache openssl1.1-compat
+RUN apk add --update --no-cache openssl
 USER node
 WORKDIR /usr/src/app
 
@@ -26,7 +26,7 @@ COPY --chown=node:node --from=builder /tmp/build/app/node_modules/@prisma ./node
 COPY --chown=node:node --from=builder /tmp/build/app/node_modules/.prisma ./node_modules/.prisma
 
 FROM --platform=linux/amd64 node:18.15.0-alpine
-RUN apk add --update --no-cache openssl1.1-compat
+RUN apk add --update --no-cache openssl
 USER node
 WORKDIR /usr/src/app
 COPY --chown=node:node --from=builder /tmp/build/app/package.json ./


### PR DESCRIPTION
Hello,

I just wanted to let you know that I've made a change to the image build for this project. Specifically, I've updated the version of OpenSSL used from [openssl1.1-compat](https://pkgs.alpinelinux.org/packages?name=openssl1.1-compat-libs-static) to [openssl](https://pkgs.alpinelinux.org/packages?name=openssl&branch=edge&repo=&arch=&maintainer=). This change was necessary to resolve an issue with connecting to the database using Prisma. Previously, we were experiencing a Segmentation fault (core dumped) error, but this change should fix that problem.

Please let me know if you have any questions or concerns about this change. Thanks!